### PR TITLE
Specify depends for overlayfs

### DIFF
--- a/bladerunner.nix
+++ b/bladerunner.nix
@@ -161,11 +161,8 @@ in
         "lowerdir=/sysroot/${rostore}"
         "upperdir=/sysroot/${scratch}/upperdir"
         "workdir=/sysroot/${scratch}/workdir"
-      ];
-      depends = [
-        "/sysroot/${rostore}"
-        "/sysroot/${scratch}/upperdir"
-        "/sysroot/${scratch}/workdir"
+        "x-systemd.requires=/sysroot/${scratch}"
+        "x-systemd.requires=/sysroot/${rostore}"
       ];
     };
 

--- a/bladerunner.nix
+++ b/bladerunner.nix
@@ -162,6 +162,11 @@ in
         "upperdir=/sysroot/${scratch}/upperdir"
         "workdir=/sysroot/${scratch}/workdir"
       ];
+      depends = [
+        "/sysroot/${rostore}"
+        "/sysroot/${scratch}/upperdir"
+        "/sysroot/${scratch}/workdir"
+      ];
     };
 
     system.build.ukiconf = (pkgs.formats.ini { }).generate "uki.conf" {


### PR DESCRIPTION
Attempt to fix dependency issues of filesystems because `/nix` was attempted to mount before the nbd device and thus failed.

IMHO this should be automated, and I opened https://github.com/NixOS/nixpkgs/issues/276886 for this.